### PR TITLE
[BUG] Fixing request body logging 

### DIFF
--- a/RestSharp.Serilog.Auto.Tests/RestClientAutologTest.cs
+++ b/RestSharp.Serilog.Auto.Tests/RestClientAutologTest.cs
@@ -1,5 +1,6 @@
 using Serilog;
 using System;
+using System.Linq;
 using Xunit;
 
 namespace RestSharp.Serilog.Auto.Tests
@@ -357,6 +358,130 @@ namespace RestSharp.Serilog.Auto.Tests
             Assert.True(restResponse.IsSuccessful);
         }
 
+        [Fact]
+        public void Should_Execute_RestRequest_With_ValidJson_OnlyHeader()
+        {  
+            // arrange
+            var client = new RestClientAutolog("http://pruu.herokuapp.com/dump/restsharpAutoLog-test");
+            var restRequest = new RestRequest(Method.POST);
+            restRequest.AddHeader("Content-Type","application/json");
+
+            //act
+            var restResponse = client.Execute(restRequest);
+
+            // assert
+            Assert.Equal(DefaultMessage, client.Configuration.MessageTemplateForError);
+            Assert.Equal(DefaultMessage, client.Configuration.MessageTemplateForSuccess);
+            Assert.Null(client.Configuration.LoggerConfiguration);
+            Assert.Equal("pruu.herokuapp.com", client.BaseUrl.Host);
+            Assert.Equal(Method.POST, restResponse.Request.Method);
+            Assert.Equal(200, (int)restResponse.StatusCode);
+            Assert.Equal("OK", restResponse.Content);
+            Assert.Single(restResponse.Request.Parameters);
+            Assert.True(restResponse.IsSuccessful);
+        }
+
+        [Fact]
+        public void Should_Execute_RestRequest_With_ValidJson_OnlyRequestBody()
+        {
+            // arrange
+            var client = new RestClientAutolog("http://pruu.herokuapp.com/dump/restsharpAutoLog-test");
+            var restRequest = new RestRequest(Method.POST);
+            restRequest.AddParameter("Name", "Value", ParameterType.RequestBody);
+
+            // act
+            var restResponse = client.Execute(restRequest);
+
+            // assert
+            Assert.Equal(DefaultMessage, client.Configuration.MessageTemplateForError);
+            Assert.Equal(DefaultMessage, client.Configuration.MessageTemplateForSuccess);
+            Assert.Null(client.Configuration.LoggerConfiguration);
+            Assert.Equal("pruu.herokuapp.com", client.BaseUrl.Host);
+            Assert.Equal(Method.POST, restResponse.Request.Method);
+            Assert.Equal(200, (int)restResponse.StatusCode);
+            Assert.Equal("OK", restResponse.Content);
+            Assert.Single(restResponse.Request.Parameters);
+            Assert.True(restResponse.IsSuccessful);
+        }
+        
+        [Fact]
+        public void Should_Execute_RestRequest_With_ValidJson_WithoutName()
+        {
+            // arrange
+            var client = new RestClientAutolog("http://pruu.herokuapp.com/dump/restsharpAutoLog-test");
+            var restRequest = new RestRequest(Method.POST);
+            restRequest.AddParameter("", "Value", ParameterType.RequestBody);
+
+            // act
+            var restResponse = client.Execute(restRequest);
+
+            // act
+            Assert.Equal(DefaultMessage, client.Configuration.MessageTemplateForError);
+            Assert.Equal(DefaultMessage, client.Configuration.MessageTemplateForSuccess);
+            Assert.Null(client.Configuration.LoggerConfiguration);
+            Assert.Equal("pruu.herokuapp.com", client.BaseUrl.Host);
+            Assert.Equal(Method.POST, restResponse.Request.Method);
+            Assert.Equal(200, (int)restResponse.StatusCode);
+            Assert.Equal("OK", restResponse.Content);
+            Assert.Single(restResponse.Request.Parameters);
+            Assert.Equal("", restResponse.Request.Parameters.FirstOrDefault().Name);
+            Assert.True(restResponse.IsSuccessful);
+        }
+
+        [Fact]
+        public void Should_Execute_RestRequest_With_ValidJson_Only_With_DataFormat()
+        {
+            // arrange
+            var client = new RestClientAutolog("http://pruu.herokuapp.com/dump/restsharpAutoLog-test");
+            var restRequest = new RestRequest(Method.POST);
+            restRequest.AddParameter("", "", ParameterType.RequestBody);
+            restRequest.Parameters.FirstOrDefault().DataFormat = DataFormat.Json;
+
+            // act
+            var restResponse = client.Execute(restRequest);
+
+            // assert
+            Assert.Equal(DefaultMessage, client.Configuration.MessageTemplateForError);
+            Assert.Equal(DefaultMessage, client.Configuration.MessageTemplateForSuccess);
+            Assert.Null(client.Configuration.LoggerConfiguration);
+            Assert.Equal("pruu.herokuapp.com", client.BaseUrl.Host);
+            Assert.Equal(Method.POST, restResponse.Request.Method);
+            Assert.Equal(200, (int)restResponse.StatusCode);
+            Assert.Equal("OK", restResponse.Content);
+            Assert.Single(restResponse.Request.Parameters);
+            Assert.Equal("", restResponse.Request.Parameters.FirstOrDefault().Name);
+            Assert.Equal("", restResponse.Request.Parameters.FirstOrDefault().Value);
+            Assert.Equal(DataFormat.Json, restResponse.Request.Parameters.FirstOrDefault().DataFormat);
+            Assert.True(restResponse.IsSuccessful);
+        }
+
+        [Fact]
+        public void Should_Execute_RestRequest_With_ValidJson_Only_With_ContentType()
+        {
+            // arrange
+            var client = new RestClientAutolog("http://pruu.herokuapp.com/dump/restsharpAutoLog-test");
+            var restRequest = new RestRequest(Method.POST);
+            restRequest.AddParameter("", "", ParameterType.RequestBody);
+            restRequest.Parameters.FirstOrDefault().ContentType = "application/json";
+
+            // act
+            var restResponse = client.Execute(restRequest);
+
+            // assert
+
+            Assert.Equal(DefaultMessage, client.Configuration.MessageTemplateForError);
+            Assert.Equal(DefaultMessage, client.Configuration.MessageTemplateForSuccess);
+            Assert.Null(client.Configuration.LoggerConfiguration);
+            Assert.Equal("pruu.herokuapp.com", client.BaseUrl.Host);
+            Assert.Equal(Method.POST, restResponse.Request.Method);
+            Assert.Equal(200, (int)restResponse.StatusCode);
+            Assert.Equal("OK", restResponse.Content);
+            Assert.Single(restResponse.Request.Parameters);
+            Assert.Equal("", restResponse.Request.Parameters.FirstOrDefault().Name);
+            Assert.Equal("", restResponse.Request.Parameters.FirstOrDefault().Value);
+            Assert.Equal("application/json", restResponse.Request.Parameters.FirstOrDefault().ContentType);
+            Assert.True(restResponse.IsSuccessful);
+        }
     }
 
     public class User

--- a/RestSharp.Serilog.Auto/RestClientAutolog.cs
+++ b/RestSharp.Serilog.Auto/RestClientAutolog.cs
@@ -206,9 +206,9 @@ namespace RestSharp
                 p.Value?.ToString().Contains("json") == true)
                 ||
                 (p.Type == ParameterType.RequestBody &&
-                 p.Name?.ToString().Contains("json") == true ||
+                (p.Name?.ToString().Contains("json") == true ||
                  p.DataFormat == DataFormat.Json ||
-                 p.ContentType?.Contains("application/json") == true))
+                 p.ContentType?.Contains("application/json") == true)))
                 ?? false;
 
             var isForm = request?.Parameters?.Exists(p =>
@@ -221,7 +221,7 @@ namespace RestSharp
             {
                 if (isJson)
                 {
-                    var content = JsonConvert.SerializeObject(body.Value);
+                    var content = (body.Value is string) ? body.Value.ToString() : JsonConvert.SerializeObject(body.Value);
                     return this.GetContentAsObjectByContentTypeJson(content, true, this.Configuration.JsonBlacklist);
                 }
                 

--- a/RestSharp.Serilog.Auto/RestClientAutolog.cs
+++ b/RestSharp.Serilog.Auto/RestClientAutolog.cs
@@ -1,4 +1,5 @@
 ﻿using JsonMasking;
+using Newtonsoft.Json;
 using PackUtils;
 using Serilog;
 using Serilog.Context;
@@ -201,11 +202,13 @@ namespace RestSharp
 
             var isJson = request?.Parameters?.Exists(p => 
                 (p.Type == ParameterType.HttpHeader &&
-                p.Name == "Content-Type" && 
+                (p.Name == "Content-Type") && 
                 p.Value?.ToString().Contains("json") == true)
                 ||
                 (p.Type == ParameterType.RequestBody &&
-                p.Name?.ToString().Contains("json") == true))
+                 p.Name?.ToString().Contains("json") == true ||
+                 p.DataFormat == DataFormat.Json ||
+                 p.ContentType?.Contains("application/json") == true))
                 ?? false;
 
             var isForm = request?.Parameters?.Exists(p =>
@@ -218,7 +221,8 @@ namespace RestSharp
             {
                 if (isJson)
                 {
-                    return this.GetContentAsObjectByContentTypeJson(body.Value.ToString(), true, this.Configuration.JsonBlacklist);
+                    var content = JsonConvert.SerializeObject(body.Value);
+                    return this.GetContentAsObjectByContentTypeJson(content, true, this.Configuration.JsonBlacklist);
                 }
                 
                 if (isForm)


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

### Status

READY

### Whats?

Fix request body logging issue

### Why?

Because before these changes was logging just the namespace string, not the request body.

### How?

First of all, there was a property "name" that was used to verify if the request is a json or not. That property was aways empty. And a property "value" in the body variable was passed to a method with toString, that was the source of the problem.