### PR TITLE
fix: Update RestClientAutolog.cs

### DIFF
--- a/RestSharp.Serilog.Auto/RestClientAutolog.cs
+++ b/RestSharp.Serilog.Auto/RestClientAutolog.cs
@@ -146,7 +146,7 @@ namespace RestSharp
                 return;
             }
 
-            if (this.Configuration.LoggerConfiguration != null)
+            if (this.Configuration.LoggerConfiguration == null)
             {
                 Log.Logger = this.Configuration.LoggerConfiguration.CreateLogger();
             }


### PR DESCRIPTION
Should create logger only when it's not created yet.
Received error here - when trying to make second  new RestRequest on the Same RestClient.

Have checked this fix on my machine and code. Works well.
Could you please check it and make new package plz.
Thanks!