### PR TITLE
[Feature] Implements jsonblacklist by request and response

### DIFF
--- a/RestSharp.Serilog.Auto.ConsoleTest/Program.cs
+++ b/RestSharp.Serilog.Auto.ConsoleTest/Program.cs
@@ -29,7 +29,7 @@ namespace RestSharp.Serilog.Auto.ConsoleTest
             RestClientAutolog client = new RestClientAutolog("http://pruu.herokuapp.com");
             client.AddDefaultHeader("DefaultHeaderTest", "SomeValue");
 
-            client.Configuration.JsonBlacklist = new string[] { "*password" };
+            client.Configuration.RequestJsonBlacklist = new string[] { "*password" };
 
             RestRequest request = new RestRequest("dump/{name}", Method.POST);
             request.AddHeader("RequestCustomHeader", "SomeValue2");

--- a/RestSharp.Serilog.Auto.Tests/RestClientAutologTest.cs
+++ b/RestSharp.Serilog.Auto.Tests/RestClientAutologTest.cs
@@ -297,7 +297,7 @@ namespace RestSharp.Serilog.Auto.Tests
         {
             // arrange
             var client = new RestClientAutolog("https://reqres.in/api/users");
-            client.Configuration.JsonBlacklist = new string[] { "*job" };
+            client.Configuration.RequestJsonBlacklist = new string[] { "*job" };
             var restRequest = new RestRequest(Method.POST);
             restRequest.AddHeader("X-Forwarded-For", "127.0.0.1");
             restRequest.AddJsonBody(new

--- a/RestSharp.Serilog.Auto/RestClientAutolog.cs
+++ b/RestSharp.Serilog.Auto/RestClientAutolog.cs
@@ -278,7 +278,7 @@ namespace RestSharp
                 if (isJson)
                 {
                     var content = (body.Value is string) ? body.Value.ToString() : JsonConvert.SerializeObject(body.Value);
-                    return this.GetContentAsObjectByContentTypeJson(content, true, this.Configuration.JsonBlacklist);
+                    return this.GetContentAsObjectByContentTypeJson(content, true, this.Configuration.RequestJsonBlacklist);
                 }
                 
                 if (isForm)
@@ -298,7 +298,7 @@ namespace RestSharp
                 
             if (content != null && isJson == true)
             {
-                return this.GetContentAsObjectByContentTypeJson(content, false, null);
+                return this.GetContentAsObjectByContentTypeJson(content, true, this.Configuration.ResponseJsonBlacklist);
             }
 
             return content;

--- a/RestSharp.Serilog.Auto/RestClientAutologConfiguration.cs
+++ b/RestSharp.Serilog.Auto/RestClientAutologConfiguration.cs
@@ -1,5 +1,7 @@
 ﻿using Serilog;
 using Serilog.Events;
+
+using System;
 using System.Collections.Generic;
 using System.Net;
 
@@ -43,7 +45,21 @@ namespace RestSharp
             }
         }
 
-        public string[] JsonBlacklist { get; set; }
+        /// <summary>
+        /// This property will redirect to the property 'RequestJsonBlacklist'. So, when you get/set it's value,
+        /// what you are actually doing is using the other one.
+        /// You should actually use the 'RequestJsonBlacklist' to dismiss the obsolete warning.
+        /// </summary>
+        [Obsolete("Keeping this property to retrocompatibility and to not break the code when updating the library.")]
+        public string[] JsonBlacklist 
+        {
+            get => RequestJsonBlacklist;
+            set => RequestJsonBlacklist = value;
+        }
+
+        public string[] RequestJsonBlacklist { get; set; }
+
+        public string[] ResponseJsonBlacklist { get; set; }
 
         public bool EnabledLog { get; set; } = true;
 


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

### Whats?

Implemented the json black list feature by request and response to make it easier to control what properties will be hidden.

### Why?

Because i needed to blacklist the response when log is enabled. It was disabled by default, so i took advantage to make this feature.

### How?

Added two variables to store each it's json blacklists words. I left the old variable in place to not break the code when we update this library in some project.
