### PR TITLE
✨ Adds query string headers masking

### DIFF
--- a/RestSharp.Serilog.Auto/RestClientAutologConfiguration.cs
+++ b/RestSharp.Serilog.Auto/RestClientAutologConfiguration.cs
@@ -60,6 +60,10 @@ namespace RestSharp
         public string[] RequestJsonBlacklist { get; set; }
 
         public string[] ResponseJsonBlacklist { get; set; }
+        
+        public string[] HeaderBlacklist { get; set; }
+
+        public string[] QueryStringBlacklist { get; set; }
 
         public bool EnabledLog { get; set; } = true;
 


### PR DESCRIPTION
### Whats?

Implements a way to mask fields in the query string and headers.

### Why?

Because it is needed to mask some fields when logging not only in the request but other fields too.

### How?

Added new methods to handle the field masking. 
Added fields in the configuration file to store and separate the fields that we need to mask.