### PR TITLE
Fixed default variables docs on README.md and implemented ProtocolVersion default variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ var loggerConfiguration = new LoggerConfiguration()
 
 var restClientAutologConfiguration = new RestClientAutologConfiguration()
 {
-    MessageTemplateForSuccess = "{Method} {Uri} responded {StatusCode}", 
-    MessageTemplateForError = "{Method} {Uri} is not good! {ErrorMessage}", 
+    MessageTemplateForSuccess = "{Method} {Url} responded {StatusCode}", 
+    MessageTemplateForError = "{Method} {Url} is not good! {ErrorMessage}", 
     LoggerConfiguration = loggerConfiguration
 };
 
@@ -57,21 +57,24 @@ Default variables:
 * `Url`
 * `Host`
 * `Path`
+* `Port`
+* `QueryString`
 * `Query`
 * `RequestBody`
 * `RequestHeaders`
 * `StatusCode`
+* `StatusCodeFamily`
 * `StatusDescription`
 * `ResponseStatus`
-* `ProtocolVersion`
 * `IsSuccessful`
 * `ErrorMessage`
 * `ErrorException`
-* `Content`
-* `ContentEncoding`
+* `ResponseContent`
 * `ContentLength`
 * `ContentType`
+* `ContentEncoding`
 * `ResponseHeaders`
+* `ProtocolVersion`
 
 ## Setup global max length for exception properties
 

--- a/RestSharp.Serilog.Auto/RestClientAutolog.cs
+++ b/RestSharp.Serilog.Auto/RestClientAutolog.cs
@@ -188,7 +188,7 @@ namespace RestSharp
             properties.Add("RequestHeaders", this.GetRequestHeaders(response.Request, true));
             properties.Add("StatusCode", (int)response.StatusCode);
             properties.Add("StatusCodeFamily", ((int)response.StatusCode).ToString()[0] + "XX");
-            properties.Add("StatusDescription", response.StatusDescription?.Replace(" ",""));
+            properties.Add("StatusDescription", response.StatusDescription?.Replace(" ", ""));
             properties.Add("ResponseStatus", response.ResponseStatus.ToString());
             properties.Add("IsSuccessful", response.IsSuccessful);
             properties.Add("ErrorMessage", exceptionMessage);
@@ -198,6 +198,7 @@ namespace RestSharp
             properties.Add("ContentType", response.ContentType);
             properties.Add("ResponseHeaders", this.GetResponseHeaders(response, true));
             properties.Add("Environment", Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"));
+            properties.Add("ProtocolVersion", response.ProtocolVersion?.ToString());
 
             foreach (var property in properties)
             {


### PR DESCRIPTION
:bug: fixed default variables docs on README.md
:bug: fixed default variable ProtocolVersion which was present in the docs but wasn't implemented

### Status

READY / IN DEVELOPMENT

### Whats?

While using this library on a test project, found the I wasn't able to log the URL of the request and content of a response body. After some search in the source code of the library, I spoted that the issue was in the README.md docs.
I also spoted the mention of the default variable ProtocolVersion but noticed the this wasn't implemented.

### Why?

For a better understanding of whoever comes after. : )

### How?

About the docs, fixed the README.md.
About the ProtocolVersion default variable, I added it in RestSharp.Serilog.Auto/RestClientAutolog.cs in the same method where the other variables are processed.